### PR TITLE
Python 3 Compatible

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -56,7 +56,11 @@ from win32com.client import constants as _constants
 import win32com.client
 import pythoncom
 import time
-import thread
+
+try:
+    import thread
+except ImportError:
+    import _thread as thread
 
 # Make sure that we've got our COM wrappers generated.
 from win32com.client import gencache
@@ -154,7 +158,7 @@ def input(prompt=None, phraselist=None):
         listener.stoplistening()
 
     if prompt:
-        print prompt
+        print(prompt)
 
     if phraselist:
         listener = listenfor(phraselist, response)


### PR DESCRIPTION
*Edit:
Please ignore this - it was an automated push from my app. I can't delete the pull request.

Just these two changes are required for python 3. There is a potential breaking change for anyone printing _not strings_ as a `prompt` in python 2 - as with this change it may print as tuple. But given the function signature and documentation, its not the expected usage.